### PR TITLE
Add MustCustomASCII function.

### DIFF
--- a/nanoid.go
+++ b/nanoid.go
@@ -176,6 +176,24 @@ func CustomUnicode(alphabet string, length int) (generator, error) {
 }
 
 /*
+MustCustomASCII is like CustomASCII but panics if an error would have normally
+been returned It simplifies safe initialization of global variables
+
+Returns a Nano ID generator which uses a custom ASCII alphabet.
+
+🟡 Panics if alphabet is not valid ASCII or if length is not, or within 2-255.
+
+🧿 Concurrency safe.
+*/
+func MustCustomASCII(alphabet string, length int) generator {
+	genFunc, err := CustomASCII(alphabet, length)
+	if err != nil {
+		panic(`nanoid: CustomASCII(` + alphabet + `): ` + err.Error())
+	}
+	return genFunc
+}
+
+/*
 Returns a Nano ID generator which uses a custom ASCII alphabet.
 
 Uses less memory than CustomUnicode by only supporting ASCII.

--- a/nanoid_test.go
+++ b/nanoid_test.go
@@ -44,6 +44,24 @@ func TestCustom(t *testing.T) {
 	})
 }
 
+func TestMustCustom(t *testing.T) {
+	t.Run("general", func(t *testing.T) {
+		f := nanoid.MustCustomASCII("abcdef", 21)
+		id := f()
+		assert.Len(t, id, 21, "should return the same length as the ID specified length")
+		t.Log(id)
+	})
+}
+
+func TestMustCustomPanic(t *testing.T) {
+	t.Run("general", func(t *testing.T) {
+		f := func() {
+			nanoid.MustCustomASCII("abcdef", 1)
+		}
+		assert.Panics(t, f, "MustCustomASCII should have paniced")
+	})
+}
+
 func TestFlatDistribution(t *testing.T) {
 	tries := 500_000
 


### PR DESCRIPTION
Resolves [jaevor/go-nanoid#2](https://github.com/jaevor/go-nanoid/pull/2)

Does not implement `MustCustomUnicode`.
