### PR TITLE
fix: prevent infinite loop when length < 5 in Custom generators

### DIFF
--- a/nanoid.go
+++ b/nanoid.go
@@ -125,6 +125,9 @@ func CustomUnicode(alphabet string, length int) (generator, error) {
 	clz := bits.LeadingZeros32(x | 1)
 	mask := (2 << (31 - clz)) - 1
 	step := (length / 5) * 8
+	if step < length {
+		step = length
+	}
 
 	b := make([]byte, step)
 	id := make([]rune, length)
@@ -190,6 +193,9 @@ func CustomASCII(alphabet string, length int) (generator, error) {
 	clz := bits.LeadingZeros32(x | 1)
 	mask := (2 << (31 - clz)) - 1
 	step := (length / 5) * 8
+	if step < length {
+		step = length
+	}
 
 	b := make([]byte, step)
 	id := make([]byte, length)


### PR DESCRIPTION
Fixes #10

## Problem

When `length < 5`, `CustomASCII` and `CustomUnicode` enter an infinite loop:

```go
gen, _ := nanoid.CustomASCII("abc123", 3) // hangs forever
gen()
```

## Root Cause

```go
step := (length / 5) * 8
```

Integer division: `3 / 5 = 0`, so `step = 0`. The random byte buffer is zero-length, `crand.Read(b)` reads nothing, and the inner `for i := 0; i < 0; i++` never executes — making the outer `for {}` spin forever.

## Fix

Ensure `step` is at least `length`:

```go
step := (length / 5) * 8
if step < length {
    step = length
}
```

All existing tests pass. Tested with lengths 2, 3, 4, 5, 10, 21.